### PR TITLE
README.md fixes/cleanups; Python3 support; errors to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,76 @@
 Cert-Reorder
 ============
 
-A python script to re-order the certificates in a pen formatted file.  One of the applications we run requires that the certificates be in a particular order (server, intermediate, CA) and our CA provided the certificates in the opposite order (CA, intermediate, server) so I wrote this script to correct the ordering.
+A python script to re-order the certificates in a PEM formatted file. One of the applications we run requires that the certificates be in a particular order
+(server, intermediate, CA) that conforms to [RFC5246](https://tools.ietf.org/html/rfc5246#section-7.4.2) and our CA provided the certificates in the opposite
+order (CA, intermediate, server) so I wrote this script to correct the ordering.
 
-While the ultimate goal would be to have the ability to list the certificates in an arbitrary order, this currently is not supported.  Adding that functionality would be trivial, I had a perl script which would do just that, but the specific use case I wrote the script to solve, the certificates were always in CA, intermediate, server certificate and I needed them in the opposite order so I initially implemented a reversing operation `-r` and then later also  implemented an automatic option `-a`
+While the ultimate goal would be to have the ability to list the certificates in an arbitrary order, this currently is not supported. Adding that functionality
+would be trivial. I had a perl script which would do just that, but for this specific use case that I wrote the script to solve, the input certificates were
+always in CA, intermediate, server certificate irder and I needed them in the opposite order so I initially implemented a reversing operation `-r` and then
+later also  implemented an automatic option `-a`
 
-###Contributions
-This script is licensed under fairly liberal terms, so please feel free to use it and hopefully make your life easier.  If you do find bugs, want to contribute new features, etc please fork it, make the change, and make a pull request.  For simple changes, you can also e-mail me either a diff or a complete script if its not too big.
+### Contributions
 
-###Splunk Compatability
-This script utilizes PyOpenSSL; the python bundled with Splunk includes this library, so it should be easy fairly easy to run.  By default the script utilizes the standard python shebang line `#!/usr/bin/env python` which should invoke the systems version of python. It also includes an example on the third line of directly utilizing the python bundled with Splunk (assuming $SPLUNKHOME is /opt/splunk) `#!/opt/splunk/bin/splunk cmd python`  If you replace the first line with this, (assuming you modify /opt/splunk to point to your $SPLUNKHOME) then it should work.
+This script is licensed under fairly liberal terms, so please feel free to use it and hopefully make your life easier.  If you do find bugs, want to contribute
+new features, etc please fork it, make the change, and make a pull request. For simple changes, you can also e-mail me either a diff or a complete script if it
+isn't too big.
 
-##Usage
+### Splunk Compatability
 
-To reverse the certificate order in the pen file:
-    ./cert-reorder.py -r certificatechain.pem
+This script utilizes PyOpenSSL; the python bundled with Splunk includes this library, so it should be easy fairly easy to run.  By default the script utilizes
+the standard python shebang line `#!/usr/bin/env python` which should invoke the systems version of python. It also includes an example on the third line of
+directly utilizing the python bundled with Splunk (assuming `$SPLUNKHOME` is `/opt/splunk`) `#!/opt/splunk/bin/splunk cmd python` If you replace the first line
+with this, (assuming you modify `/opt/splunk` to point to your `$SPLUNKHOME`) then it should work.
 
-To analyze the certificates and put them in CA, intermediate, server order:
-    ./cert-reorder.py -a certificatechain.pem
-    
-If you want to analyze the certificates and put them in server, intermediate, CA order you can use two invocations:
-    ./cert-reorder.py -a certificatechain.pem | ./cert-reorder.py -r
-    
+## Usage
+
+To reverse the certificate order in the PEM file:
+
+```sh
+./cert-reorder.py -r certificatechain.pem
+```
+
+To analyze the certificates and put them in server, intermediate, CA order:
+
+```sh
+./cert-reorder.py -a certificatechain.pem
+```
+
+If you want to analyze the certificates and put them in CA, intermediate, server order you can use two invocations:
+
+```sh
+./cert-reorder.py -a certificatechain.pem | ./cert-reorder.py -r
+```
+
 If you want to verify the order of a certificate chain, you can use the -p option:
-    ./cert-reorder.py -p certificatechain.pem
-    
-If you want to verify the order of the certificates after a command, you can save the results in a file and then use the previous command to print the common names of the certificates or you can just run the command and pipe the output back to cert-reorder.py
-    ./cert-reorder.py -a certificatechain.pem | ./cert-reorder.py -p
+
+```sh
+./cert-reorder.py -p certificatechain.pem
+```
+
+If you want to verify the order of the certificates after a command, you can save the results in a file and then use the previous command to print the common
+names of the certificates or you can just run the command and pipe the output back to cert-reorder.py
+
+```sh
+./cert-reorder.py -a certificatechain.pem | ./cert-reorder.py -p
+```
 
 
-###Program Usage Output
-> usage: cert-reorder.py [-h] [-r | -p | -a] [file]
-> 
-> Manipulate the order of certificates in a pem style file
->
-> positional arguments:
->   file
->
-> optional arguments:
->  -h, --help     show this help message and exit
->  -r, --reverse  Reverse the order of certificates.
->  -p, --print
->  -a, --auto
+### Program Usage Output
+
+```console
+$ ./cert-reorder.py -h
+usage: cert-reorder.py [-h] [-r | -p | -a] [file]
+
+Manipulate the order of certificates in a pem style file
+
+positional arguments:
+  file
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -r, --reverse  Reverse the order of certificates.
+  -p, --print
+  -a, --auto
+```

--- a/cert-reorder.py
+++ b/cert-reorder.py
@@ -8,14 +8,13 @@ import sys
 import OpenSSL
 
 def buildParser():
-    parser = argparse.ArgumentParser(description='Manipulate the order of certificates in a pem style file')
-    parser.add_argument('file', type=argparse.FileType('r'), default='-', nargs="?")
-    action = parser.add_mutually_exclusive_group()
-    action.add_argument('-r', '--reverse', dest='action', action='store_const',
-                   const=reverse, default=interactive, help='Reverse the order of certificates.')
-    action.add_argument('-p', '--print', dest='action', action='store_const', const=print_cert_name, help="")
-    action.add_argument('-a', '--auto', dest='action', action='store_const', const=auto, help='')
-    return parser
+	parser = argparse.ArgumentParser(description='Manipulate the order of certificates in a pem style file')
+	parser.add_argument('file', type=argparse.FileType('r'), default='-', nargs="?")
+	action = parser.add_mutually_exclusive_group()
+	action.add_argument('-r', '--reverse', dest='action', action='store_const', const=reverse, default=interactive, help='Reverse the order of certificates.')
+	action.add_argument('-p', '--print', dest='action', action='store_const', const=print_cert_name, help="")
+	action.add_argument('-a', '--auto', dest='action', action='store_const', const=auto, help='')
+	return parser
 
 
 class CertParser:
@@ -50,16 +49,15 @@ class CertParser:
 
 	def get_common_name(self, cert):
 		return OpenSSL.crypto.load_certificate(OpenSSL.crypto.FILETYPE_PEM, cert).get_subject().commonName
-		
 
 def reverse(certs):
 	certs.reverse()
-	print asChain(certs)
+	print(asChain(certs))
 
 def print_cert_name(certs):
 	p = CertParser()
 	for cert in certs:
-		print p.get_common_name(cert)
+		print(p.get_common_name(cert))
 
 def asChain(certs):
 	return "\n".join(certs)
@@ -96,10 +94,10 @@ def auto(certs):
 			break
 		chain.insert(0, next)
 	chain = [c['text'] for c in chain ]
-	print asChain(chain)
+	print(asChain(chain))
 
 def interactive(certs):
-	print "Not yet implemented"
+	sys.stderr.write("Not yet implemented\n")
 
 if __name__ == '__main__':
 	args = buildParser().parse_args()


### PR DESCRIPTION
- Fixed up formatting in README.md so that it looks nice.
- Fix errors in README.md (when describing the effect of various options).
- Changed print to print() to add support for Python3 (it continues to work in Python2).
- Minor code reformatting to be consistent with the rest of the file.
- As per Unix/Linux conventions, errors to standard-error.